### PR TITLE
Make app generated from `rake dummy_app` usable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,13 @@ desc "Generates a dummy app for testing"
 task :test_app do
   ENV["LIB_NAME"] = "proclaimer"
   Rake::Task["extension:test_app"].invoke
+  Rake::Task["test_app:cleanup"].invoke
+end
+
+desc "Remove references to JavaScript and CSS files from dummy app"
+task "test_app:cleanup" do
+  Dir["#{__dir__}/spec/dummy/vendor/**/all.{css,js}"].each do |path|
+    content = File.read(path).sub(%r<^.*require spree/\S+/proclaimer.*$>, "")
+    File.open(path, "w") { |file| file.write(content) }
+  end
 end


### PR DESCRIPTION
Spree adds a line to include JavaScript and CSS into dummy app by default and there is no way to turn that off. The only way to work around that is to delete those offending lines so the dummy app would boot up.