### PR TITLE
Refunds now instrument an event

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ PATH
   remote: .
   specs:
     proclaimer (0.1.0)
-      spree_core (~> 2.4.6)
+      spree_backend (~> 2.4.6)
 
 GEM
   remote: https://rubygems.org/
@@ -132,8 +132,6 @@ GEM
       xpath (~> 2.0)
     carmen (1.0.2)
       activesupport (>= 3.0.0)
-    childprocess (0.5.6)
-      ffi (~> 1.0, >= 1.0.11)
     cldr-plurals-runtime-rb (1.0.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
@@ -170,7 +168,6 @@ GEM
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     ffaker (1.32.1)
-    ffi (1.9.10)
     font-awesome-rails (4.4.0.0)
       railties (>= 3.2, < 5.0)
     friendly_id (5.0.5)
@@ -273,7 +270,6 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    rubyzip (1.1.7)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -282,11 +278,6 @@ GEM
       sprockets-rails (~> 2.0)
     select2-rails (3.5.9.1)
       thor (~> 0.14)
-    selenium-webdriver (2.47.1)
-      childprocess (~> 0.5)
-      multi_json (~> 1.0)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -322,7 +313,6 @@ GEM
       tzinfo
     warden (1.2.3)
       rack (>= 1.0)
-    websocket (1.2.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -334,11 +324,9 @@ DEPENDENCIES
   coffee-rails
   database_cleaner
   factory_girl (~> 4.5)
-  ffaker
   proclaimer!
   rspec-rails (~> 3.1)
   sass-rails (~> 4.0.2)
-  selenium-webdriver
   simplecov
   spree!
   spree_auth_devise!

--- a/app/controllers/spree/admin/refunds_controller_decorator.rb
+++ b/app/controllers/spree/admin/refunds_controller_decorator.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Admin
+    RefundsController.class_eval do
+      create.after :notify_subscribers_on_successful_refund
+
+      private
+
+      def notify_subscribers_on_successful_refund
+        ActiveSupport::Notifications.instrument(
+          "spree.refunds.create",
+          refund: @object
+        )
+      end
+    end
+  end
+end

--- a/proclaimer.gemspec
+++ b/proclaimer.gemspec
@@ -18,16 +18,14 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "spree_core", "~> 2.4.6"
+  s.add_dependency "spree_backend", "~> 2.4.6"
 
   s.add_development_dependency "capybara", "~> 2.4"
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "factory_girl", "~> 4.5"
-  s.add_development_dependency "ffaker"
   s.add_development_dependency "rspec-rails",  "~> 3.1"
   s.add_development_dependency "sass-rails", "~> 4.0.2"
-  s.add_development_dependency "selenium-webdriver"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "sqlite3"
 end

--- a/spec/controllers/spree/admin/refunds_controller_spec.rb
+++ b/spec/controllers/spree/admin/refunds_controller_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+RSpec.describe Spree::Admin::RefundsController do
+  stub_authorization!
+
+  describe "POST #create" do
+    let(:payment) { create(:payment, amount: 10.00) }
+    let(:refund_reason) { create(:refund_reason) }
+
+    it "sends a notification with refund as a payload" do
+      payload = nil
+
+      ActiveSupport::Notifications.subscribe("spree.refunds.create") do |*args|
+        payload = args.last
+      end
+
+      spree_post \
+        :create,
+        refund: { amount: "10.00", refund_reason_id: refund_reason.to_param },
+        order_id: payment.order.to_param,
+        payment_id: payment.to_param
+
+      expect(payload).not_to be_nil
+      expect(payload[:refund]).to eq Spree::Refund.last
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,4 +81,8 @@ RSpec.configure do |config|
 
   config.fail_fast = ENV["FAIL_FAST"] || false
   config.order = "random"
+
+  # Include helpers for controller test
+  config.include Spree::TestingSupport::ControllerRequests, type: :controller
+  config.include Devise::TestHelpers, type: :controller
 end


### PR DESCRIPTION
This event is instrumented using ActiveSupport::Notifications, and can be subscribed by any other piece of code.