### PR TITLE
Add ActiveSupport::Notifications instruments to various refund-related endpoints

### DIFF
--- a/app/controllers/spree/admin/customer_returns_controller_decorator.rb
+++ b/app/controllers/spree/admin/customer_returns_controller_decorator.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Admin
+    CustomerReturnsController.class_eval do
+      create.after :notify_subscribers_on_successful_create
+
+      private
+
+      def notify_subscribers_on_successful_create
+        ActiveSupport::Notifications.instrument(
+          "spree.customer_return.create",
+          customer_return: @object
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/spree/admin/reimbursements_controller_decorator.rb
+++ b/app/controllers/spree/admin/reimbursements_controller_decorator.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Admin
+    ReimbursementsController.class_eval do
+      create.after :notify_subscribers_on_successful_create
+
+      private
+
+      def notify_subscribers_on_successful_create
+        ActiveSupport::Notifications.instrument(
+          "spree.reimbursement.create",
+          reimbursement: @object
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/spree/admin/return_authorizations_controller_decorator.rb
+++ b/app/controllers/spree/admin/return_authorizations_controller_decorator.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Admin
+    ReturnAuthorizationsController.class_eval do
+      create.after :notify_subscribers_on_successful_create
+
+      private
+
+      def notify_subscribers_on_successful_create
+        ActiveSupport::Notifications.instrument(
+          "spree.return_authorization.create",
+          return_authorization: @object
+        )
+      end
+    end
+  end
+end

--- a/spec/controllers/spree/admin/customer_returns_controller_spec.rb
+++ b/spec/controllers/spree/admin/customer_returns_controller_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+RSpec.describe Spree::Admin::CustomerReturnsController do
+  stub_authorization!
+
+  describe "POST #create" do
+    let(:order) { create(:shipped_order) }
+    let(:inventory_unit) { order.inventory_units.first }
+    let(:return_item) { create(:return_item, inventory_unit: inventory_unit) }
+    let(:return_authorization) {
+      create(:return_authorization, order: order, return_items: [return_item])
+    }
+    let(:stock_location) { create(:stock_location) }
+
+    it "sends a notification with customer_return as a payload" do
+      payload = nil
+
+      ActiveSupport::Notifications.
+        subscribe("spree.customer_return.create") do |*args|
+        payload = args.last
+      end
+
+      spree_post \
+        :create,
+        order_id: order.to_param,
+        customer_return: {
+          stock_location_id: stock_location.id,
+          return_items_attributes: {
+            "0" => {
+              id: return_item.id,
+              returned: "1",
+              pre_tax_amount: "10.00",
+              inventory_unit_id: inventory_unit.id
+            }
+          }
+        }
+
+      expect(payload).not_to be_nil
+      expect(payload[:customer_return]).to eq Spree::CustomerReturn.last
+    end
+  end
+end

--- a/spec/controllers/spree/admin/reimbursements_controller_spec.rb
+++ b/spec/controllers/spree/admin/reimbursements_controller_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+RSpec.describe Spree::Admin::ReimbursementsController do
+  stub_authorization!
+
+  describe "POST #create" do
+    let(:customer_return) { create(:customer_return_with_accepted_items) }
+    let(:order) { customer_return.order }
+
+    it "sends a notification with reimbursement as a payload" do
+      payload = nil
+
+      ActiveSupport::Notifications.
+        subscribe("spree.reimbursement.create") do |*args|
+        payload = args.last
+      end
+
+      spree_post \
+        :create,
+        order_id: order.to_param,
+        build_from_customer_return_id: customer_return.id
+
+
+      expect(payload).not_to be_nil
+      expect(payload[:reimbursement]).to eq Spree::Reimbursement.first
+    end
+  end
+end

--- a/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+RSpec.describe Spree::Admin::ReturnAuthorizationsController do
+  stub_authorization!
+
+  describe "POST #create" do
+    let(:order) { create(:shipped_order) }
+    let(:shipment) { order.shipments.first }
+    let(:inventory_unit) { order.inventory_units.first }
+    let(:return_authorization_reason) { create(:return_authorization_reason) }
+
+    it "sends a notification with return_authorization as a payload" do
+      payload = nil
+
+      ActiveSupport::Notifications.
+        subscribe("spree.return_authorization.create") do |*args|
+        payload = args.last
+      end
+
+      spree_post \
+        :create,
+        order_id: order.to_param,
+        return_authorization: {
+          stock_location_id: shipment.stock_location.to_param,
+          return_authorization_reason_id: return_authorization_reason.to_param,
+          return_items_attributes: {
+            0 => {
+              inventory_unit_id: inventory_unit.to_param,
+              pre_tax_amount: shipment.pre_tax_amount.to_s
+            }
+          }
+        }
+
+      expect(payload).not_to be_nil
+      expect(payload[:return_authorization]).
+        to eq Spree::ReturnAuthorization.last
+    end
+  end
+end


### PR DESCRIPTION
Instruments have been added on these endpoints:

* return_authorizations#create
* customer_returns#create
* reimbursements#create