### PR TITLE
Add DSL to setup subscription to Spree event

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,30 @@ bundle
 bundle exec rails g proclaimer:install
 ```
 
+Usage
+-----
+
+Use `Proclaimer.configure` block to setup subscription:
+
+```ruby
+Proclaimer.configure do |config|
+  # Subscribe to a particular event
+  config.subscribe("order.complete") do |event, payload|
+    # ...
+  end
+
+  # Subscribe to any events related to order
+  config.subscribe("order") do |event, payload|
+    # ...
+  end
+
+  # Subscribe to any Spree events
+  config.subscribe_all do |event, payload|
+    # ...
+  end
+end
+```
+
 Testing
 -------
 

--- a/lib/proclaimer.rb
+++ b/lib/proclaimer.rb
@@ -1,2 +1,9 @@
 require "spree_core"
 require "proclaimer/engine"
+require "proclaimer/configuration"
+
+module Proclaimer
+  def self.configure(&block)
+    Configuration.new.instance_eval(&block)
+  end
+end

--- a/lib/proclaimer/configuration.rb
+++ b/lib/proclaimer/configuration.rb
@@ -1,0 +1,24 @@
+require "active_support/notifications"
+
+module Proclaimer
+  class Configuration
+    def subscribe(event_name, callable = Proc.new)
+      if callable.respond_to?(:call)
+        ActiveSupport::Notifications.subscribe(
+          /^spree\.#{Regexp.escape(event_name)}/,
+          -> (event, *args, payload) do
+            callable.call(event, payload)
+          end
+        )
+      else
+        raise \
+          ArgumentError,
+          "Callback must be a block or object responding to #call."
+      end
+    end
+
+    def subscribe_all(callable = Proc.new)
+      subscribe("", callable)
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,102 @@
+require "spec_helper"
+require "proclaimer/configuration"
+
+RSpec.describe Proclaimer::Configuration do
+  before do
+    stub_const "PAYLOAD", Object.new
+  end
+
+  after do
+    ActiveSupport::Notifications.unsubscribe(/^spree\./)
+  end
+
+  describe "#subscribe" do
+    context "subscription" do
+      it "supports subscribing to an event with given event name" do
+        event_name = nil
+        payload = nil
+
+        configuration.subscribe("order.complete") do |*args|
+          event_name = args.first
+          payload = args.second
+        end
+
+        trigger_event "spree.order.complete", PAYLOAD
+
+        expect(event_name).to eq "spree.order.complete"
+        expect(payload).to eq PAYLOAD
+      end
+
+      it "supports subscribing to any event starting with given string" do
+        event_name = nil
+        payload = nil
+
+        configuration.subscribe("order") do |*args|
+          event_name = args.first
+          payload = args.second
+        end
+
+        trigger_event "spree.order.complete", PAYLOAD
+
+        expect(event_name).to eq "spree.order.complete"
+        expect(payload).to eq PAYLOAD
+      end
+    end
+
+    context "callable" do
+      it "raises error if the given object does not respond to call" do
+        expect { configuration.subscribe("event", :nope) }.
+          to raise_error(ArgumentError, /call/)
+      end
+    end
+  end
+
+  describe "#subscribe_all" do
+    context "subscription" do
+      it "subscribe to all spree events" do
+        event_name = nil
+        payload = nil
+
+        configuration.subscribe_all do |*args|
+          event_name = args.first
+          payload = args.second
+        end
+
+        trigger_event "spree.order.complete", PAYLOAD
+
+        expect(event_name).to eq "spree.order.complete"
+        expect(payload).to eq PAYLOAD
+      end
+
+      it "does not subscribe to non-spree event" do
+        event_name = nil
+        payload = nil
+
+        configuration.subscribe_all do |*args|
+          event_name = args.first
+          payload = args.second
+        end
+
+        trigger_event "some.other.event", {}
+
+        expect(event_name).to be_nil
+        expect(payload).to be_nil
+      end
+    end
+
+    context "callable" do
+      it "raises error if the given object does not respond to call" do
+        expect { configuration.subscribe_all(:nope) }.
+          to raise_error(ArgumentError, /call/)
+      end
+    end
+  end
+
+  def configuration
+    Proclaimer::Configuration.new
+  end
+
+  def trigger_event(event_name, payload)
+    ActiveSupport::Notifications.instrument(event_name, payload)
+  end
+end

--- a/spec/proclaimer_spec.rb
+++ b/spec/proclaimer_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+require "proclaimer"
+
+RSpec.describe Proclaimer do
+  describe "configure" do
+    it "initialize a configuration object and passing in the block" do
+      configuration = double(:configuration)
+      given_block = -> {}
+      received_block = nil
+      allow(Proclaimer::Configuration).
+        to receive(:new).and_return(configuration)
+      allow(configuration).to receive(:instance_eval) do |&block|
+        received_block = block
+      end
+
+      Proclaimer.configure(&given_block)
+
+      expect(configuration).to have_received(:instance_eval)
+      expect(received_block).to eq given_block
+    end
+  end
+end


### PR DESCRIPTION
Usage:

    Proclaimer.configure do |config|
      # Subscribe to a particular event
      config.subscribe("order.complete") do |event, payload|
        # ...
      end

      # Subscribe to any events related to order
      config.subscribe("order") do |event, payload|
        # ...
      end

      # Subscribe to any Spree events
      config.subscribe_all do |event, payload|
        # ...
      end
    end