### PR TITLE
Adding hooks into OrderUpdater#update_shipments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GIT
 PATH
   remote: .
   specs:
-    proclaimer (0.1.0)
+    proclaimer (0.2.0)
       spree_backend (~> 3.0.0)
 
 GEM

--- a/app/models/spree/order_updater_decorator.rb
+++ b/app/models/spree/order_updater_decorator.rb
@@ -1,0 +1,14 @@
+module Spree
+  OrderUpdater.class_eval do
+    def update_shipments_with_state_tracking
+      shipment_states = shipments.map(&:state)
+      update_shipments_without_state_tracking
+
+      shipments.each_with_index do |shipment, index|
+        shipment.broadcast_state if shipment_states[index] != shipment.state
+      end
+    end
+
+    alias_method_chain :update_shipments, :state_tracking
+  end
+end

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -4,9 +4,13 @@ module Spree
     state_machine.after_transition to: :ready, do: :notify_shipment_ready
     state_machine.after_transition to: :canceled, do: :notify_shipment_canceled
 
+    def broadcast_state
+      notification_event(state)
+    end
+
     private
 
-    %i(pending ready canceled).each do |type|
+    %i(pending resume ready canceled).each do |type|
       define_method(:"notify_shipment_#{type}") { notification_event type }
     end
 

--- a/lib/proclaimer/version.rb
+++ b/lib/proclaimer/version.rb
@@ -1,3 +1,3 @@
 module Proclaimer
-  VERSION = "0.1.0".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/spec/models/spree/order_updater_spec.rb
+++ b/spec/models/spree/order_updater_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+module Spree
+  RSpec.describe OrderUpdater, type: :model do
+
+    describe "#update_shipments_with_status_tracking" do
+      it "calls shipment#broadcast on shipments that have changed state" do
+        fake_shipments = [
+          fake_shipment_with_state('pending', 'ready'),
+          fake_shipment_with_state('pending')
+        ]
+        fake_order = double(Order, shipments: fake_shipments)
+        updater = described_class.new(fake_order)
+
+        updater.update_shipments
+
+        expect(fake_shipments.first).to have_received(:broadcast_state)
+        expect(fake_shipments.last).not_to have_received(:broadcast_state)
+      end
+
+      def fake_shipment_with_state(*states)
+        spy(Shipment).tap do |shipment|
+          allow(shipment).to receive(:state).and_return(*states)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What's new?
* Spree bypasses state machine callbacks when updating shipments via `OrderUpdater` this PR addresses that
* Stopped asserting the innards of `ActiveSupport::Notifications` and just make sure the outlets are receiving what we are sending.
* Added new `#broadcast_state` method to `Shipment`