### PR TITLE
Required version of ruby is now 2.1+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GIT
 PATH
   remote: .
   specs:
-    proclaimer (0.3.0)
+    proclaimer (0.3.1)
       spree_backend (~> 3.0.0)
 
 GEM
@@ -374,3 +374,6 @@ DEPENDENCIES
   spree!
   spree_auth_devise!
   sqlite3
+
+BUNDLED WITH
+   1.10.6

--- a/lib/proclaimer/version.rb
+++ b/lib/proclaimer/version.rb
@@ -1,3 +1,3 @@
 module Proclaimer
-  VERSION = "0.3.0".freeze
+  VERSION = "0.3.1".freeze
 end

--- a/proclaimer.gemspec
+++ b/proclaimer.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary = "An easy, and extensible transactional event notification " +
     "add on for Spree."
   s.description = s.summary
-  s.required_ruby_version = ">= 2.2.0"
+  s.required_ruby_version = ">= 2.1.0"
 
   s.authors = ["Prem Sichanugrist", "Vincent Franco", "David Freerksen"]
   s.homepage  = "https://github.com/groundctrl/proclaimer"


### PR DESCRIPTION
###  What's new?
A lower version requirement for Ruby as Spree 3.x is 2.1+ why not us too?